### PR TITLE
Remove host-name test for HP printers

### DIFF
--- a/fingerprint.conf
+++ b/fingerprint.conf
@@ -1340,9 +1340,7 @@ subclass "PRL" 1:3:2a:4:6:7:c:f:1a:2c:33:36:3a:3b:be {
   else { set ident = "Dell or Lexmark printer"; }
 }
 subclass "PRL" 6:3:1:f:42:43:d:c { set ident = "HP printer"; }
-subclass "PRL" 6:3:1:f:2c:c {
- if (substring(option host-name, 0, 3) = "NPI") { set ident = "HP printer"; }
-}
+subclass "PRL" 6:3:1:f:2c:c { set ident = "HP printer"; }
 subclass "PRL" 6:3:1:f:c:42:43:d:2c {
  if (substring(option host-name, 0, 3) = "NPI") { set ident = "HP printer"; }
 }


### PR DESCRIPTION
**It should probably apply to the other rules, but I don't have any printer which matches them.**

Otherwise printers which were renamed won't match the rule.
For example:

`(…) | PRL=6:3:1:f:2c:c | Vendor=[None] | Hostname=X | Client=[Unknown]`